### PR TITLE
Update loot tables for music disks in dungeons

### DIFF
--- a/src/main/resources/assets/galaxyspace/loot_tables/dungeon_tier_4.json
+++ b/src/main/resources/assets/galaxyspace/loot_tables/dungeon_tier_4.json
@@ -176,17 +176,17 @@
                 },
                 {
                     "type": "item",
-                    "name": "minecraft:record_chirp",
+                    "name": "minecraft:record_cat",
                     "weight": 4
                 },
                 {
                     "type": "item",
-                    "name": "minecraft:record_wait",
+                    "name": "minecraft:record_stal",
                     "weight": 4
                 },
                 {
                     "type": "item",
-                    "name": "minecraft:record_ward",
+                    "name": "minecraft:record_strad",
                     "weight": 4
                 },
                 {

--- a/src/main/resources/assets/galaxyspace/loot_tables/dungeon_tier_5.json
+++ b/src/main/resources/assets/galaxyspace/loot_tables/dungeon_tier_5.json
@@ -157,17 +157,12 @@
                 },
                 {
                     "type": "item",
-                    "name": "minecraft:record_chirp",
+                    "name": "minecraft:record_11",
                     "weight": 4
                 },
                 {
                     "type": "item",
-                    "name": "minecraft:record_wait",
-                    "weight": 4
-                },
-                {
-                    "type": "item",
-                    "name": "minecraft:record_ward",
+                    "name": "minecraft:record_13",
                     "weight": 4
                 },
                 {


### PR DESCRIPTION
Now all disks can be obtained by exploring space dungeons!

Ceres got the rest of melodic disks (cat, stal and strad) while Io got 11 and 13.