### PR TITLE
Change anti-radiation to a positive effect

### DIFF
--- a/src/main/java/galaxyspace/core/GSPotions.java
+++ b/src/main/java/galaxyspace/core/GSPotions.java
@@ -17,7 +17,7 @@ public class GSPotions {
 	private static void initPotions()
 	{
 		
-		antiradiation = new AntiRadiation(true, GSUtils.getColor(255, 10, 100, 10));		
+		antiradiation = new AntiRadiation(false, GSUtils.getColor(255, 10, 100, 10));		
 	
 		ForgeRegistries.POTIONS.register(antiradiation);
 	}


### PR DESCRIPTION
Noticed this from a CraftTweaker potions effects dump. From my understanding, anti-radiation is beneficial to the player, so register it as such.