### PR TITLE
Added MineTweaker support for Rocket Assembler

### DIFF
--- a/src/main/java/galaxyspace/core/integration/minetweaker/GSMinetweakerConfig.java
+++ b/src/main/java/galaxyspace/core/integration/minetweaker/GSMinetweakerConfig.java
@@ -4,6 +4,7 @@ import galaxyspace.GalaxySpace;
 import galaxyspace.core.integration.minetweaker.handlers.MTHandler_Assembler;
 import galaxyspace.core.integration.minetweaker.handlers.MTHandler_HydroponicFarm;
 import galaxyspace.core.integration.minetweaker.handlers.MTHandler_Recycler;
+import galaxyspace.core.integration.minetweaker.handlers.MTHandler_RocketAssembly;
 import minetweaker.MineTweakerAPI;
 import minetweaker.api.item.IIngredient;
 import minetweaker.api.item.IItemStack;
@@ -22,6 +23,7 @@ public class GSMinetweakerConfig {
 		MineTweakerAPI.registerClass(MTHandler_Assembler.class);
 		MineTweakerAPI.registerClass(MTHandler_Recycler.class);
 		MineTweakerAPI.registerClass(MTHandler_HydroponicFarm.class);
+		MineTweakerAPI.registerClass(MTHandler_RocketAssembly.class);
 	}
 	
 	public static ItemStack getStack(IItemStack stack) {

--- a/src/main/java/galaxyspace/core/integration/minetweaker/handlers/MTHandler_RocketAssembly.java
+++ b/src/main/java/galaxyspace/core/integration/minetweaker/handlers/MTHandler_RocketAssembly.java
@@ -1,0 +1,157 @@
+package galaxyspace.core.integration.minetweaker.handlers;
+
+import galaxyspace.systems.SolarSystem.planets.overworld.recipe.RocketAssemblyRecipes;
+import minetweaker.IUndoableAction;
+import minetweaker.MineTweakerAPI;
+import minetweaker.api.item.IIngredient;
+import minetweaker.api.item.IItemStack;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static galaxyspace.core.integration.minetweaker.GSMinetweakerConfig.getObjects;
+import static galaxyspace.core.integration.minetweaker.GSMinetweakerConfig.getStack;
+
+
+
+@ZenClass("mods.galaxyspace.RocketAssembly")
+public class MTHandler_RocketAssembly {
+
+	/**
+	 * Index:
+	 *  1 - Cone
+	 *  2 - Body Right
+	 *  3 - Body Left
+	 *  4 - Engine
+	 *  5 - Booster Top
+	 *  6 - Booster Bottom
+	 *  7 - Vane Top
+	 *  8 - Vane Bottom
+	 */
+	public static List<List<ItemStack>> material = new ArrayList<>(8);
+	static {
+		for (int i = 0; i < 8; i++) {
+			material.add(new ArrayList<>());
+		}
+	}
+	public static boolean itemIsMaterial(ItemStack s) {
+		for(List<ItemStack> list : material )
+		{
+			for(ItemStack stack : list)
+			{
+				if(stack.isItemEqual(s)) {
+					System.out.println(s.getDisplayName() + " is material, sending to slot");
+						return true;
+				}
+			}
+		}
+		System.out.println(s.getDisplayName() + " is not material");
+		return false;
+	}
+	@ZenMethod
+    public static void addRecipe(IItemStack output, IIngredient[] ingredients) {
+		System.out.println("Length of ingredients: " + ingredients.length + " Length of materials: " + material.size());
+			if(ingredients.length != 0) {
+				for (int i = 0; i < ingredients.length; i++) {
+					material.get(i).add((ItemStack)getObjects(ingredients)[i]);
+					System.out.println("Added " + ((ItemStack) getObjects(ingredients)[i]).getDisplayName() + " to materials");
+				}
+				System.out.println("Materials: " + material.toString());
+		}
+        MineTweakerAPI.apply(new Add(getStack(output), getObjects(ingredients)));
+    }
+    
+    @ZenMethod
+	public static void removeRecipe(IItemStack output) {
+		MineTweakerAPI.apply(new Remove(getStack(output)));
+	}
+    
+    private static class Add implements IUndoableAction {
+		
+    	private ItemStack stack;
+    	private Object[] objects;
+    	
+		public Add(ItemStack stack, Object[] objects) {
+			this.stack = stack;
+			this.objects = objects;
+
+		}
+
+		@Override
+		public void apply() {
+			System.out.println("Added rocket assembly recipe for: " + this.stack.getDisplayName());
+			RocketAssemblyRecipes.addShapelessRecipe(this.stack, this.objects);
+
+		}
+
+		@Override
+		public boolean canUndo() {
+			return true;
+		}
+
+		@Override
+		public void undo() {
+			RocketAssemblyRecipes.instance.removeRecipe(stack);
+		}
+
+		@Override
+		public String describe() {
+			return String.format("Adding Assembly Machine recipe for item %s", stack.getDisplayName());
+		}
+
+		@Override
+		public String describeUndo() {
+			return String.format("Removing Assembly Machine recipe for item %s", stack.getDisplayName());
+		}
+
+		@Override
+		public Object getOverrideKey() {
+			return null;
+		}
+	}  
+	
+	private static class Remove implements IUndoableAction {
+
+		private final ItemStack output;
+		List<ItemStack> removed = new ArrayList<ItemStack>();
+		
+		public Remove(ItemStack stack) {
+			output = stack;
+		}
+
+		@Override
+		public void apply() {
+			RocketAssemblyRecipes.instance.removeRecipe(output);
+		}
+
+		@Override
+		public boolean canUndo() {
+			return false;
+		}
+
+		@Override
+		public void undo() {
+			
+		}
+
+		@Override
+		public String describe() {
+			return String.format("Removing all recipes for %s", output.getUnlocalizedName());
+		}
+
+		@Override
+		public String describeUndo() {
+			return String.format("Re-adding previously removed recipes for %s", output.getUnlocalizedName());
+		}
+
+		@Override
+		public Object getOverrideKey() {
+			return null;
+		}
+	}
+
+}

--- a/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/inventory/ContainerRocketAssemblyMachine.java
+++ b/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/inventory/ContainerRocketAssemblyMachine.java
@@ -1,5 +1,6 @@
 package galaxyspace.systems.SolarSystem.planets.overworld.inventory;
 
+import galaxyspace.core.integration.minetweaker.handlers.MTHandler_RocketAssembly;
 import galaxyspace.core.registers.items.GSItems;
 import galaxyspace.systems.SolarSystem.planets.overworld.tile.TileEntityRocketAssemblyMachine;
 import micdoodle8.mods.galacticraft.api.item.IItemElectric;
@@ -188,6 +189,21 @@ public class ContainerRocketAssemblyMachine extends Container
                         return null;
                     }
                 }
+                else if (MTHandler_RocketAssembly.itemIsMaterial(var4))
+                {
+                    for(int i = 0; i < this.inventorySlots.size(); i++)
+                    {
+                        if(((Slot)inventorySlots.get(i)).isItemValid(var4) && !(((Slot)inventorySlots.get(i)).getHasStack()))
+                        {
+                            if (!this.mergeOneItem(var4, i, i+1, false))
+                            {
+                                return null;
+                            }
+                        }
+                    }
+
+                }
+
  
             }
 

--- a/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/inventory/SlotRocketAssembly.java
+++ b/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/inventory/SlotRocketAssembly.java
@@ -1,11 +1,15 @@
 package galaxyspace.systems.SolarSystem.planets.overworld.inventory;
 
+import galaxyspace.core.integration.minetweaker.handlers.MTHandler_RocketAssembly;
 import galaxyspace.core.registers.items.GSItems;
 import net.minecraft.init.Blocks;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class SlotRocketAssembly extends Slot
 {
@@ -22,64 +26,140 @@ public class SlotRocketAssembly extends Slot
     @Override
     public boolean isItemValid(ItemStack par1ItemStack)
     {
-        switch (this.index)
+		List<ItemStack> list;
+		switch (this.index)
         {
-        	case 2: return 
-        			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 0
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 5
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 10
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 15
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 20;
-        	
-        	case 3: return 
+			//Cone
+        	case 2:
+					boolean isCone = false;
+					list = MTHandler_RocketAssembly.material.get(0);
+					for(ItemStack stack : list)
+					{
+						isCone = stack.isItemEqual(par1ItemStack);
+						if(isCone)
+							return true;
+					}
+					return par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 0
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 5
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 10
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 15
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 20;
+
+        	//Body Right
+        	case 3:
+					boolean isBodyR = false;
+					list = MTHandler_RocketAssembly.material.get(1);
+					for(ItemStack stack : list)
+					{
+						isBodyR = stack.isItemEqual(par1ItemStack);
+						if(isBodyR)
+							return true;
+					}
+					return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 1
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 6
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 11
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 16
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 21;
-        	
-        	case 4: return 
+        	//Body Left
+        	case 4:
+					boolean isBodyL = false;
+					list = MTHandler_RocketAssembly.material.get(2);
+					for(ItemStack stack : list)
+					{
+						isBodyL = stack.isItemEqual(par1ItemStack);
+						if(isBodyL)
+							return true;
+					}
+					return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 1
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 6
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 11
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 16
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 21;
-        	
-        	case 5: return 
+        	//Engine
+        	case 5:
+					boolean isEngine = false;
+					list = MTHandler_RocketAssembly.material.get(3);
+					for(ItemStack stack : list)
+					{
+						isEngine = stack.isItemEqual(par1ItemStack);
+						if(isEngine)
+							return true;
+					}
+					return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 2
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 7
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 12
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 17
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 22;
-        	
-        	case 6: return 
+        	//Booster Top
+        	case 6:
+					boolean isBoosterT = false;
+					list = MTHandler_RocketAssembly.material.get(4);
+					for(ItemStack stack : list)
+					{
+						isBoosterT = stack.isItemEqual(par1ItemStack);
+						if(isBoosterT)
+							return true;
+					}
+					return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 3
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 8
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 13
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 18
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 23;
-        	
-        	case 7: return 
+        	//Booster Bottom
+        	case 7:
+					boolean isBoosterB = false;
+					list = MTHandler_RocketAssembly.material.get(5);
+					for(ItemStack stack : list)
+					{
+						isBoosterB = stack.isItemEqual(par1ItemStack);
+						if(isBoosterB)
+							return true;
+					}
+
+				return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 3
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 8
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 13
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 18
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 23;
-        	
-        	case 8: return 
+        	//Vane Top
+        	case 8:
+					boolean isVaneT = false;
+					list = MTHandler_RocketAssembly.material.get(6);
+					for(ItemStack stack : list)
+					{
+						isVaneT = stack.isItemEqual(par1ItemStack);
+						if(isVaneT)
+							return true;
+					}
+				return
         			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 4
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 9
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 14
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 19
         			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 24;
-        	
-        	case 9: return 
-        			par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 4
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 9
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 14
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 19
-        			|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 24;
-        	
+        	//Vane Bottom
+        	case 9:
+					boolean isVaneB = false;
+					list = MTHandler_RocketAssembly.material.get(7);
+					for(ItemStack stack : list)
+					{
+						isVaneB = stack.isItemEqual(par1ItemStack);
+						if(isVaneB)
+							return true;
+					}
+					return
+					par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 4
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 9
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 14
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 19
+					|| par1ItemStack.getItem() == GSItems.RocketParts && par1ItemStack.getItemDamage() == 24;
+
+        	//Chests
         	case 10: return par1ItemStack.getItem() == Item.getItemFromBlock(Blocks.chest);
         	case 11: return par1ItemStack.getItem() == Item.getItemFromBlock(Blocks.chest);
         	case 12: return par1ItemStack.getItem() == Item.getItemFromBlock(Blocks.chest);

--- a/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/recipe/CraftingRecipesOverworld.java
+++ b/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/recipe/CraftingRecipesOverworld.java
@@ -265,12 +265,20 @@ public class CraftingRecipesOverworld {
 	   RecyclerRecipes.recycling().addNewRecipe(new ItemStack(GSBlocks.Ores, 1, 3), new ItemStack(GSItems.BasicItems, 1, 16), null);
    }
    
-   private static void addRocketRecipe(Item rocket, Item parts, int metafirstparts)
+  private static void addRocketRecipe(Item rocket, Item parts, int metafirstparts)
    {
+	   /**
+		* Meta first parts:
+		* +0: Cone
+		* +1: Body
+		* +2: Engine
+		* +3: Boosters
+		* +4: Vanes/Fins
+		*/
 	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 0), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4));
-	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 1), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1),	new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4),	new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0)); 
-	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 2), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1),	new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0)); 
-	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 3), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1),	new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0));  
+	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 1), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0));
+	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 2), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0));
+	   RocketAssemblyRecipes.addShapelessRecipe(new ItemStack(rocket, 1, 3), new ItemStack(parts, 1, metafirstparts), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 1), new ItemStack(parts, 1, metafirstparts + 2), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 3), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(parts, 1, metafirstparts + 4), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0), new ItemStack(Blocks.chest, 1, 0));
    }
    
    private static void addOtherRecipes()

--- a/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/recipe/RocketAssemblyRecipes.java
+++ b/src/main/java/galaxyspace/systems/SolarSystem/planets/overworld/recipe/RocketAssemblyRecipes.java
@@ -29,6 +29,7 @@ import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapelessOreRecipe;
 
 public class RocketAssemblyRecipes {
+    public static final RocketAssemblyRecipes instance = new RocketAssemblyRecipes();
     private static List<IRecipe> recipes = new ArrayList<IRecipe>();
 
     public static ShapedRecipes addRecipe(ItemStack output, Object ... inputList) {
@@ -207,6 +208,20 @@ public class RocketAssemblyRecipes {
 
     public static List<IRecipe> getRecipeList() {
         return recipes;
+    }
+    public void removeRecipe(ItemStack stack)
+    {
+        int index = 0;
+
+        for(IRecipe recipes : getRecipeList())
+        {
+            if(recipes.getRecipeOutput().isItemEqual(stack))
+            {
+                index = getRecipeList().indexOf(recipes);
+            }
+        }
+
+        getRecipeList().remove(index);
     }
 }
 


### PR DESCRIPTION
You can now add and remove recipes for the rocket assembly using minetweaker!

```
#Removes the recipe for the tier 3 rocket with one chest
mods.galaxyspace.RocketAssembly.removeRecipe(<GalacticraftMars:item.itemTier3Rocket:1>);

#Adds an odd recipe for the infinite Battery using nothing but stone swords, has some odd side effects.
mods.galaxyspace.RocketAssembly.addRecipe(<GalacticraftCore:item.infiniteBattery>, [<minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>, <minecraft:stone_sword>]);

#Adds a really silly recipe for enchanted golden apples using all sorts of random junk.
mods.galaxyspace.RocketAssembly.addRecipe(<minecraft:golden_apple:1>, [<minecraft:dye>, <GalacticraftCore:item.battery>.withTag({electricity: 15000.0 as float}), <GalacticraftCore:item.battery>.withTag({electricity: 15000.0 as float}), <minecraft:golden_pickaxe>, <minecraft:leather>, <minecraft:leather>, <minecraft:potato>, <minecraft:potato>]);
```

Planned:
Adding MT support for other machines

-GamingB3ast 
